### PR TITLE
feat: add dark mode to blog page

### DIFF
--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -65,24 +65,30 @@
 </svelte:head>
 
 <!-- Hero Section -->
-<section class="bg-gradient-to-br from-purple-50 to-pink-50 py-16">
+<section
+	class="bg-gradient-to-br from-purple-50 to-pink-50 py-16 dark:from-purple-900 dark:to-gray-900"
+>
 	<div class="container mx-auto px-4">
 		<div class="mx-auto max-w-4xl text-center">
-			<h1 class="mb-4 text-4xl font-bold text-gray-900 lg:text-5xl">技術部落格</h1>
-			<p class="mb-8 text-xl text-gray-600">分享我在前端開發路上的學習心得與技術見解</p>
+			<h1 class="mb-4 text-4xl font-bold text-gray-900 lg:text-5xl dark:text-gray-100">
+				技術部落格
+			</h1>
+			<p class="mb-8 text-xl text-gray-600 dark:text-gray-300">
+				分享我在前端開發路上的學習心得與技術見解
+			</p>
 
 			<!-- Search Bar -->
 			<div class="mx-auto max-w-2xl">
 				<div class="relative">
 					<Search
-						class="absolute top-1/2 left-4 -translate-y-1/2 transform text-gray-400"
+						class="absolute top-1/2 left-4 -translate-y-1/2 transform text-gray-400 dark:text-gray-400"
 						size={20}
 					/>
 					<Input
 						type="text"
 						placeholder="搜尋文章..."
 						bind:value={searchQuery}
-						class="rounded-xl border-gray-200 py-3 pl-12 text-base focus:border-purple-500 focus:ring-2 focus:ring-purple-200"
+						class="rounded-xl border-gray-200 py-3 pl-12 text-base focus:border-purple-500 focus:ring-2 focus:ring-purple-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-400 dark:focus:ring-purple-800"
 					/>
 				</div>
 			</div>
@@ -91,11 +97,11 @@
 </section>
 
 <!-- Filter Section -->
-<section class="border-b border-gray-100 bg-white py-8">
+<section class="border-b border-gray-100 bg-white py-8 dark:border-gray-700 dark:bg-gray-800">
 	<div class="container mx-auto px-4">
 		<div class="mx-auto max-w-6xl">
 			<div class="flex flex-wrap items-center gap-4">
-				<div class="flex items-center gap-2 text-gray-600">
+				<div class="flex items-center gap-2 text-gray-600 dark:text-gray-300">
 					<Filter size={18} />
 					<span class="font-medium">篩選標籤：</span>
 				</div>
@@ -122,7 +128,7 @@
 				{/each}
 			</div>
 
-			<div class="mt-4 text-sm text-gray-500">
+			<div class="mt-4 text-sm text-gray-500 dark:text-gray-400">
 				共找到 {filteredPosts.length} 篇文章
 			</div>
 		</div>
@@ -130,7 +136,7 @@
 </section>
 
 <!-- Blog Posts Grid -->
-<section class="bg-gray-50 py-16">
+<section class="bg-gray-50 py-16 dark:bg-gray-900">
 	<div class="container mx-auto px-4">
 		<div class="mx-auto max-w-6xl">
 			{#if filteredPosts.length > 0}
@@ -144,12 +150,14 @@
 			{:else}
 				<div class="py-16 text-center">
 					<div
-						class="mx-auto mb-6 flex h-24 w-24 items-center justify-center rounded-full bg-gray-200"
+						class="mx-auto mb-6 flex h-24 w-24 items-center justify-center rounded-full bg-gray-200 dark:bg-gray-700"
 					>
-						<Search class="text-gray-400" size={32} />
+						<Search class="text-gray-400 dark:text-gray-400" size={32} />
 					</div>
-					<h3 class="mb-2 text-xl font-semibold text-gray-900">找不到相關文章</h3>
-					<p class="mb-6 text-gray-600">試試調整搜尋關鍵字或選擇不同的標籤</p>
+					<h3 class="mb-2 text-xl font-semibold text-gray-900 dark:text-gray-100">
+						找不到相關文章
+					</h3>
+					<p class="mb-6 text-gray-600 dark:text-gray-300">試試調整搜尋關鍵字或選擇不同的標籤</p>
 					<Button
 						onclick={() => {
 							searchQuery = '';

--- a/src/routes/blog/components/BlogCard.svelte
+++ b/src/routes/blog/components/BlogCard.svelte
@@ -11,10 +11,12 @@
 </script>
 
 <article
-	class="group flex h-full flex-col overflow-hidden rounded-2xl border border-gray-200/60 bg-white shadow-md transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-purple-100/50"
+	class="group flex h-full flex-col overflow-hidden rounded-2xl border border-gray-200/60 bg-white shadow-md transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-purple-100/50 dark:border-gray-700 dark:bg-gray-800 dark:hover:shadow-purple-900/50"
 >
 	<!-- Image Container -->
-	<div class="relative overflow-hidden rounded-t-2xl bg-gradient-to-br from-purple-50 to-blue-50">
+	<div
+		class="relative overflow-hidden rounded-t-2xl bg-gradient-to-br from-purple-50 to-blue-50 dark:from-purple-900 dark:to-blue-900"
+	>
 		<img
 			class="h-48 w-full object-cover transition-all duration-500 group-hover:scale-110"
 			src={card?.image || defaultImageUrl}
@@ -26,14 +28,18 @@
 			class="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent opacity-60 transition-opacity duration-300 group-hover:opacity-80"
 		></div>
 		<!-- Decorative corner accent -->
-		<div class="absolute top-4 right-4 h-2 w-2 rounded-full bg-white/30 backdrop-blur-sm"></div>
+		<div
+			class="absolute top-4 right-4 h-2 w-2 rounded-full bg-white/30 backdrop-blur-sm dark:bg-gray-500/30"
+		></div>
 	</div>
 
 	<!-- Content Container -->
-	<div class="flex flex-1 flex-col bg-gradient-to-b from-white to-gray-50/30 p-6">
+	<div
+		class="flex flex-1 flex-col bg-gradient-to-b from-white to-gray-50/30 p-6 dark:from-gray-800 dark:to-gray-900"
+	>
 		<!-- Title -->
 		<h2
-			class="mb-3 line-clamp-2 text-xl leading-tight font-bold text-gray-900 transition-colors group-hover:text-purple-700"
+			class="mb-3 line-clamp-2 text-xl leading-tight font-bold text-gray-900 transition-colors group-hover:text-purple-700 dark:text-gray-100 dark:group-hover:text-purple-400"
 		>
 			<a
 				href={`/blog/${card.id}`}
@@ -44,7 +50,7 @@
 		</h2>
 
 		<!-- Brief -->
-		<p class="mb-4 line-clamp-3 flex-1 text-base leading-relaxed text-gray-600">
+		<p class="mb-4 line-clamp-3 flex-1 text-base leading-relaxed text-gray-600 dark:text-gray-300">
 			{card.brief}
 		</p>
 
@@ -53,14 +59,14 @@
 			<div class="mb-5 flex flex-wrap gap-2">
 				{#each card.tags.slice(0, 3) as tag}
 					<span
-						class="inline-flex items-center gap-1.5 rounded-full border border-purple-100 bg-gradient-to-r from-purple-50 to-blue-50 px-3 py-1.5 text-xs font-medium text-purple-700 transition-all hover:scale-105 hover:shadow-sm"
+						class="inline-flex items-center gap-1.5 rounded-full border border-purple-100 bg-gradient-to-r from-purple-50 to-blue-50 px-3 py-1.5 text-xs font-medium text-purple-700 transition-all hover:scale-105 hover:shadow-sm dark:border-purple-800 dark:from-purple-900 dark:to-blue-900 dark:text-purple-300"
 					>
-						<Tag size={12} class="text-purple-500" />
+						<Tag size={12} class="text-purple-500 dark:text-purple-400" />
 						{tag}
 					</span>
 				{/each}
 				{#if card.tags.length > 3}
-					<span class="self-center text-xs font-medium text-gray-400"
+					<span class="self-center text-xs font-medium text-gray-400 dark:text-gray-500"
 						>+{card.tags.length - 3} 更多</span
 					>
 				{/if}
@@ -68,10 +74,10 @@
 		{/if}
 
 		<!-- Read More Button -->
-		<div class="mt-auto border-t border-gray-100 pt-2">
+		<div class="mt-auto border-t border-gray-100 pt-2 dark:border-gray-700">
 			<a
 				href={`/blog/${card.id}`}
-				class="inline-flex items-center gap-2 py-2 text-sm font-semibold text-purple-600 transition-all duration-300 group-hover:gap-3 hover:text-purple-700"
+				class="inline-flex items-center gap-2 py-2 text-sm font-semibold text-purple-600 transition-all duration-300 group-hover:gap-3 hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-300"
 			>
 				<span class="relative">
 					閱讀更多
@@ -81,7 +87,7 @@
 				</span>
 				<ArrowRight
 					size={16}
-					class="transition-all duration-300 group-hover:translate-x-1 group-hover:text-purple-700"
+					class="transition-all duration-300 group-hover:translate-x-1 group-hover:text-purple-700 dark:group-hover:text-purple-400"
 				/>
 			</a>
 		</div>


### PR DESCRIPTION
## Summary
- add dark theme support to blog listing page and search/filter sections
- update blog card component to adapt colors in dark mode

## Testing
- `npx prettier --check src/routes/blog/+page.svelte src/routes/blog/components/BlogCard.svelte`
- `npx eslint src/routes/blog/+page.svelte src/routes/blog/components/BlogCard.svelte`
- `npm test` *(fails: PUBLIC_FIREBASE_API_KEY is not exported by "virtual:env/static/public")*

------
https://chatgpt.com/codex/tasks/task_e_689d41d7346483309687bbf54435cd85