### PR TITLE
feat: enable dark mode on practice page

### DIFF
--- a/src/routes/practices/+page.svelte
+++ b/src/routes/practices/+page.svelte
@@ -46,7 +46,9 @@
 </svelte:head>
 
 <!-- Hero Section -->
-<section class="bg-gradient-to-br from-emerald-50 to-teal-50 py-16">
+<section
+	class="bg-gradient-to-br from-emerald-50 to-teal-50 py-16 dark:from-emerald-900 dark:to-teal-900"
+>
 	<div class="container mx-auto px-4">
 		<div class="mx-auto max-w-4xl text-center">
 			<div class="mb-6 flex justify-center">
@@ -56,21 +58,23 @@
 					<Code class="text-white" size={32} />
 				</div>
 			</div>
-			<h1 class="mb-4 text-4xl font-bold text-gray-900 lg:text-5xl">程式練習</h1>
-			<p class="mb-8 text-xl text-gray-600">日常的程式練習與實驗，記錄學習過程中的小作品</p>
+			<h1 class="mb-4 text-4xl font-bold text-gray-900 lg:text-5xl dark:text-gray-100">程式練習</h1>
+			<p class="mb-8 text-xl text-gray-600 dark:text-gray-400">
+				日常的程式練習與實驗，記錄學習過程中的小作品
+			</p>
 
 			<!-- Search Bar -->
 			<div class="mx-auto max-w-2xl">
 				<div class="relative">
 					<Search
-						class="absolute top-1/2 left-4 -translate-y-1/2 transform text-gray-400"
+						class="absolute top-1/2 left-4 -translate-y-1/2 transform text-gray-400 dark:text-gray-500"
 						size={20}
 					/>
 					<input
 						type="text"
 						placeholder="搜尋練習..."
 						bind:value={searchQuery}
-						class="w-full rounded-xl border border-gray-200 py-3 pr-4 pl-12 transition-all focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 focus:outline-none"
+						class="w-full rounded-xl border border-gray-200 bg-white py-3 pr-4 pl-12 transition-all focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400 dark:focus:ring-emerald-900"
 					/>
 				</div>
 			</div>
@@ -79,11 +83,11 @@
 </section>
 
 <!-- Filter Section -->
-<section class="border-b border-gray-100 bg-white py-8">
+<section class="border-b border-gray-100 bg-white py-8 dark:border-gray-700 dark:bg-gray-900">
 	<div class="container mx-auto px-4">
 		<div class="mx-auto max-w-6xl">
 			<div class="flex flex-wrap items-center gap-4">
-				<div class="flex items-center gap-2 text-gray-600">
+				<div class="flex items-center gap-2 text-gray-600 dark:text-gray-400">
 					<Filter size={18} />
 					<span class="font-medium">篩選類型：</span>
 				</div>
@@ -108,7 +112,7 @@
 				{/each}
 			</div>
 
-			<div class="mt-4 text-sm text-gray-500">
+			<div class="mt-4 text-sm text-gray-500 dark:text-gray-400">
 				共找到 {filteredPractices.length} 個練習
 			</div>
 		</div>
@@ -116,7 +120,7 @@
 </section>
 
 <!-- Practice Grid -->
-<section class="bg-gray-50 py-16">
+<section class="bg-gray-50 py-16 dark:bg-gray-800">
 	<div class="container mx-auto px-4">
 		<div class="mx-auto max-w-6xl">
 			{#if filteredPractices.length > 0}
@@ -130,12 +134,14 @@
 			{:else}
 				<div class="py-16 text-center">
 					<div
-						class="mx-auto mb-6 flex h-24 w-24 items-center justify-center rounded-full bg-gray-200"
+						class="mx-auto mb-6 flex h-24 w-24 items-center justify-center rounded-full bg-gray-200 dark:bg-gray-700"
 					>
-						<Search class="text-gray-400" size={32} />
+						<Search class="text-gray-400 dark:text-gray-500" size={32} />
 					</div>
-					<h3 class="mb-2 text-xl font-semibold text-gray-900">找不到相關練習</h3>
-					<p class="mb-6 text-gray-600">試試調整搜尋關鍵字或選擇不同的類型</p>
+					<h3 class="mb-2 text-xl font-semibold text-gray-900 dark:text-gray-100">
+						找不到相關練習
+					</h3>
+					<p class="mb-6 text-gray-600 dark:text-gray-400">試試調整搜尋關鍵字或選擇不同的類型</p>
 					<button
 						onclick={() => {
 							searchQuery = '';
@@ -152,39 +158,45 @@
 </section>
 
 <!-- Stats Section -->
-<section class="bg-white py-16">
+<section class="bg-white py-16 dark:bg-gray-900">
 	<div class="container mx-auto px-4">
 		<div class="mx-auto max-w-4xl">
-			<h2 class="mb-8 text-center text-2xl font-bold text-gray-900">練習統計</h2>
+			<h2 class="mb-8 text-center text-2xl font-bold text-gray-900 dark:text-gray-100">練習統計</h2>
 			<div class="grid grid-cols-1 gap-6 md:grid-cols-3">
 				<div class="stat-card">
-					<div class="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-100">
+					<div
+						class="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-100 dark:bg-blue-900"
+					>
 						<Palette class="text-blue-600" size={24} />
 					</div>
-					<div class="mb-2 text-3xl font-bold text-gray-900">
+					<div class="mb-2 text-3xl font-bold text-gray-900 dark:text-gray-100">
 						{data.practice.filter((p) => p.type === 'css').length}
 					</div>
-					<div class="text-gray-600">CSS 練習</div>
+					<div class="text-gray-600 dark:text-gray-400">CSS 練習</div>
 				</div>
 
 				<div class="stat-card">
-					<div class="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-yellow-100">
+					<div
+						class="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-yellow-100 dark:bg-yellow-900"
+					>
 						<Code class="text-yellow-600" size={24} />
 					</div>
-					<div class="mb-2 text-3xl font-bold text-gray-900">
+					<div class="mb-2 text-3xl font-bold text-gray-900 dark:text-gray-100">
 						{data.practice.filter((p) => p.type === 'js').length}
 					</div>
-					<div class="text-gray-600">JavaScript 練習</div>
+					<div class="text-gray-600 dark:text-gray-400">JavaScript 練習</div>
 				</div>
 
 				<div class="stat-card">
-					<div class="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-emerald-100">
+					<div
+						class="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-emerald-100 dark:bg-emerald-900"
+					>
 						<Zap class="text-emerald-600" size={24} />
 					</div>
-					<div class="mb-2 text-3xl font-bold text-gray-900">
+					<div class="mb-2 text-3xl font-bold text-gray-900 dark:text-gray-100">
 						{data.practice.length}
 					</div>
-					<div class="text-gray-600">總練習數</div>
+					<div class="text-gray-600 dark:text-gray-400">總練習數</div>
 				</div>
 			</div>
 		</div>
@@ -195,11 +207,11 @@
 	@reference "tailwindcss";
 
 	.filter-tag {
-		@apply inline-flex items-center gap-1 rounded-full border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-600 transition-all hover:border-emerald-300 hover:text-emerald-600;
+		@apply inline-flex items-center gap-1 rounded-full border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-600 transition-all hover:border-emerald-300 hover:text-emerald-600 dark:border-gray-700 dark:text-gray-300 dark:hover:border-emerald-600 dark:hover:text-emerald-400;
 	}
 
 	.filter-tag.active {
-		@apply border-emerald-300 bg-emerald-100 text-emerald-700;
+		@apply border-emerald-300 bg-emerald-100 text-emerald-700 dark:border-emerald-600 dark:bg-emerald-900 dark:text-emerald-100;
 	}
 
 	.practice-card-wrapper {
@@ -207,6 +219,6 @@
 	}
 
 	.stat-card {
-		@apply rounded-xl border border-gray-100 bg-white p-6 text-center shadow-sm transition-shadow hover:shadow-md;
+		@apply rounded-xl border border-gray-100 bg-white p-6 text-center shadow-sm transition-shadow hover:shadow-md dark:border-gray-700 dark:bg-gray-800;
 	}
 </style>

--- a/src/routes/practices/components/PracticeCard.svelte
+++ b/src/routes/practices/components/PracticeCard.svelte
@@ -31,11 +31,11 @@
 	const getTypeColor = (type: string) => {
 		switch (type) {
 			case 'css':
-				return 'bg-blue-100 text-blue-800 border-blue-200';
+				return 'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900 dark:text-blue-200 dark:border-blue-700';
 			case 'js':
-				return 'bg-yellow-100 text-yellow-800 border-yellow-200';
+				return 'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-700';
 			default:
-				return 'bg-gray-100 text-gray-800 border-gray-200';
+				return 'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-600';
 		}
 	};
 
@@ -55,13 +55,13 @@
 	const getDifficultyColor = (difficulty: string) => {
 		switch (difficulty) {
 			case 'easy':
-				return 'bg-green-100 text-green-800';
+				return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
 			case 'medium':
-				return 'bg-yellow-100 text-yellow-800';
+				return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
 			case 'hard':
-				return 'bg-red-100 text-red-800';
+				return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
 			default:
-				return 'bg-gray-100 text-gray-800';
+				return 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200';
 		}
 	};
 
@@ -93,9 +93,9 @@
 			/>
 			{#if !card.image}
 				<div
-					class="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-gray-100 to-gray-200"
+					class="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-800 dark:to-gray-700"
 				>
-					<Icon class="text-gray-400" size={48} />
+					<Icon class="text-gray-400 dark:text-gray-500" size={48} />
 				</div>
 			{/if}
 		</div>
@@ -127,7 +127,7 @@
 
 				<!-- Title -->
 				<h3
-					class="mb-3 line-clamp-2 text-lg font-bold text-gray-900 transition-colors group-hover:text-emerald-600"
+					class="mb-3 line-clamp-2 text-lg font-bold text-gray-900 transition-colors group-hover:text-emerald-600 dark:text-gray-100 dark:group-hover:text-emerald-400"
 				>
 					<a href={path} class="hover:underline">
 						{card.title}
@@ -136,7 +136,7 @@
 
 				<!-- Description (if available) -->
 				{#if card.description}
-					<p class="mb-4 line-clamp-2 text-sm text-gray-600">
+					<p class="mb-4 line-clamp-2 text-sm text-gray-600 dark:text-gray-300">
 						{card.description}
 					</p>
 				{/if}
@@ -145,12 +145,14 @@
 				{#if card.tags && card.tags.length > 0}
 					<div class="mb-4 flex flex-wrap gap-1">
 						{#each card.tags.slice(0, 3) as tag}
-							<span class="rounded bg-gray-100 px-2 py-1 text-xs text-gray-600">
+							<span
+								class="rounded bg-gray-100 px-2 py-1 text-xs text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+							>
 								#{tag}
 							</span>
 						{/each}
 						{#if card.tags.length > 3}
-							<span class="text-xs text-gray-400">+{card.tags.length - 3}</span>
+							<span class="text-xs text-gray-400 dark:text-gray-500">+{card.tags.length - 3}</span>
 						{/if}
 					</div>
 				{/if}
@@ -158,14 +160,14 @@
 
 			<!-- Action Area -->
 			<div class="flex items-center justify-between">
-				<div class="text-xs text-gray-500">
+				<div class="text-xs text-gray-500 dark:text-gray-400">
 					練習 #{card.id}
 				</div>
 
 				<div class="flex items-center gap-2">
 					<a
 						href={path}
-						class="inline-flex items-center gap-2 text-sm font-medium text-emerald-600 transition-all group-hover:gap-3 hover:text-emerald-700"
+						class="inline-flex items-center gap-2 text-sm font-medium text-emerald-600 transition-all group-hover:gap-3 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300"
 					>
 						查看練習
 						<ArrowRight size={16} class="transition-transform group-hover:translate-x-1" />
@@ -180,7 +182,7 @@
 	@reference "tailwindcss";
 
 	.practice-card {
-		@apply cursor-pointer overflow-hidden rounded-xl border border-gray-100 bg-white shadow-sm transition-all duration-300 hover:shadow-lg;
+		@apply cursor-pointer overflow-hidden rounded-xl border border-gray-100 bg-white shadow-sm transition-all duration-300 hover:shadow-lg dark:border-gray-700 dark:bg-gray-800;
 	}
 
 	.line-clamp-2 {


### PR DESCRIPTION
## Summary
- add dark theme variants to practice listing page
- implement dark styling for practice cards

## Testing
- `npm test` *(fails: PUBLIC_FIREBASE_API_KEY is not exported)*
- `npm run lint` *(fails: code style issues found in repository)*
- `npx prettier src/routes/practices/+page.svelte src/routes/practices/components/PracticeCard.svelte --check`
- `npx eslint src/routes/practices/+page.svelte src/routes/practices/components/PracticeCard.svelte`

------
https://chatgpt.com/codex/tasks/task_e_689d41f0c2148330878e95647819d148