### PR TITLE
feat: add dark mode to practice pages

### DIFF
--- a/src/routes/practices/components/PracticeLayout.svelte
+++ b/src/routes/practices/components/PracticeLayout.svelte
@@ -44,11 +44,11 @@
 	const getTypeColor = (type: string) => {
 		switch (type) {
 			case 'css':
-				return 'bg-blue-100 text-blue-800 border-blue-200';
+				return 'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900 dark:text-blue-200 dark:border-blue-700';
 			case 'js':
-				return 'bg-yellow-100 text-yellow-800 border-yellow-200';
+				return 'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-700';
 			default:
-				return 'bg-gray-100 text-gray-800 border-gray-200';
+				return 'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-600';
 		}
 	};
 
@@ -56,13 +56,13 @@
 	const getDifficultyColor = (difficulty: string) => {
 		switch (difficulty) {
 			case 'easy':
-				return 'bg-green-100 text-green-800';
+				return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
 			case 'medium':
-				return 'bg-yellow-100 text-yellow-800';
+				return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
 			case 'hard':
-				return 'bg-red-100 text-red-800';
+				return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
 			default:
-				return 'bg-gray-100 text-gray-800';
+				return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200';
 		}
 	};
 
@@ -99,12 +99,14 @@
 </svelte:head>
 
 <!-- Header -->
-<header class="sticky top-0 z-10 border-b border-gray-200 bg-white">
+<header
+	class="sticky top-0 z-10 border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+>
 	<div class="container mx-auto px-4 py-4">
 		<div class="flex items-center justify-between">
 			<button
 				onclick={() => goto('/practices')}
-				class="inline-flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
+				class="inline-flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
 			>
 				<ArrowLeft size={18} />
 				回到練習列表
@@ -134,8 +136,11 @@
 <!-- Practice Info -->
 <Collapsible.Root>
 	<Collapsible.Trigger onclick={() => (open = !open)} class="flex items-center justify-between">
-		<div class="flex items-center gap-2 px-3 py-2 text-gray-500">
-			<span class="text-gray-600 transition-colors hover:text-gray-900">練習重點</span>
+		<div class="flex items-center gap-2 px-3 py-2 text-gray-500 dark:text-gray-400">
+			<span
+				class="text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
+				>練習重點</span
+			>
 
 			{#if open}
 				<ChevronUp size={18} />
@@ -145,19 +150,21 @@
 		</div>
 	</Collapsible.Trigger>
 	<Collapsible.Content>
-		<section class="bg-gradient-to-br from-gray-50 to-blue-50 py-12">
+		<section
+			class="bg-gradient-to-br from-gray-50 to-blue-50 py-12 dark:from-gray-900 dark:to-blue-900"
+		>
 			<div class="container mx-auto px-4">
 				<div class="mx-auto max-w-4xl">
-					<div class="mb-4 flex items-center gap-2 text-sm text-gray-600">
+					<div class="mb-4 flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
 						<span>練習 #{practiceInfo.id}</span>
 						<span>•</span>
 						<span>{getTypeName(practiceInfo.type)} 練習</span>
 					</div>
 
-					<h1 class="mb-4 text-3xl font-bold text-gray-900 lg:text-4xl">
+					<h1 class="mb-4 text-3xl font-bold text-gray-900 lg:text-4xl dark:text-gray-100">
 						{practiceInfo.title}
 					</h1>
-					<p class="mb-6 text-lg text-gray-600">
+					<p class="mb-6 text-lg text-gray-600 dark:text-gray-300">
 						{practiceInfo.description}
 					</p>
 
@@ -165,7 +172,7 @@
 					<div class="mb-6 flex flex-wrap gap-2">
 						{#each practiceInfo.tags as tag}
 							<span
-								class="rounded-full border border-gray-200 bg-white/80 px-3 py-1 text-sm text-gray-700 backdrop-blur-sm"
+								class="rounded-full border border-gray-200 bg-white/80 px-3 py-1 text-sm text-gray-700 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-800/80 dark:text-gray-300"
 							>
 								#{tag}
 							</span>
@@ -173,14 +180,18 @@
 					</div>
 
 					<!-- Key Concepts -->
-					<div class="rounded-xl border border-gray-200 bg-white/80 p-6 backdrop-blur-sm">
-						<h3 class="mb-4 flex items-center gap-2 text-lg font-semibold text-gray-900">
+					<div
+						class="rounded-xl border border-gray-200 bg-white/80 p-6 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-800/80"
+					>
+						<h3
+							class="mb-4 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-gray-100"
+						>
 							<Lightbulb size={20} />
 							主要概念
 						</h3>
 						<div class="grid grid-cols-1 gap-3 md:grid-cols-2">
 							{#each practiceInfo.concepts as concept}
-								<div class="flex items-center gap-2 text-gray-700">
+								<div class="flex items-center gap-2 text-gray-700 dark:text-gray-300">
 									<div class="h-2 w-2 rounded-full bg-blue-500"></div>
 									{concept}
 								</div>
@@ -202,24 +213,27 @@
 
 <!-- Code Explanation -->
 {#if practiceInfo.codeExamples && practiceInfo.codeExamples.length > 0}
-	<section class="bg-white py-16">
+	<section class="bg-white py-16 dark:bg-gray-800">
 		<div class="container mx-auto px-4">
 			<div class="mx-auto max-w-4xl">
-				<h2 class="mb-8 flex items-center gap-2 text-2xl font-bold text-gray-900">
+				<h2
+					class="mb-8 flex items-center gap-2 text-2xl font-bold text-gray-900 dark:text-gray-100"
+				>
 					<Code size={24} />
 					實作說明
 				</h2>
 
 				<div class="space-y-8">
 					{#each practiceInfo.codeExamples as example, index}
-						<div class="rounded-xl bg-gray-50 p-6">
-							<h3 class="mb-4 text-lg font-semibold text-gray-900">
+						<div class="rounded-xl bg-gray-50 p-6 dark:bg-gray-900">
+							<h3 class="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
 								{index + 1}. {example.title}
 							</h3>
-							<p class="mb-4 text-gray-700">
+							<p class="mb-4 text-gray-700 dark:text-gray-300">
 								{example.description}
 							</p>
-							<pre class="overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm text-gray-100"><code
+							<pre
+								class="overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm text-gray-100 dark:bg-gray-950"><code
 									>{example.code}</code
 								></pre>
 						</div>
@@ -231,16 +245,22 @@
 {/if}
 
 <!-- Tips Section -->
-<section class="bg-gradient-to-br from-blue-50 to-indigo-50 py-12">
+<section
+	class="bg-gradient-to-br from-blue-50 to-indigo-50 py-12 dark:from-gray-800 dark:to-indigo-900"
+>
 	<div class="container mx-auto px-4">
 		<div class="mx-auto max-w-4xl">
-			<div class="rounded-xl border border-blue-200 bg-white/80 p-6 backdrop-blur-sm">
-				<h3 class="mb-4 flex items-center gap-2 text-lg font-semibold text-gray-900">
+			<div
+				class="rounded-xl border border-blue-200 bg-white/80 p-6 backdrop-blur-sm dark:border-blue-800 dark:bg-gray-800/80"
+			>
+				<h3
+					class="mb-4 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-gray-100"
+				>
 					<Info size={20} />
 					學習重點
 				</h3>
 				{#if tips}{@render tips()}{:else}
-					<p class="text-gray-700">
+					<p class="text-gray-700 dark:text-gray-300">
 						這個練習幫助你理解 {getTypeName(practiceInfo.type)} 的核心概念，通過實際操作加深對相關技術的理解。
 					</p>
 				{/if}
@@ -253,7 +273,7 @@
 	@reference "tailwindcss";
 
 	.practice-demo-section {
-		@apply min-h-screen bg-gray-900;
+		@apply min-h-screen bg-gray-50 dark:bg-gray-900;
 	}
 
 	.demo-container {

--- a/src/routes/practices/css/1/+page.svelte
+++ b/src/routes/practices/css/1/+page.svelte
@@ -82,13 +82,15 @@ document.querySelectorAll('.box').forEach(box => {
 	{#snippet tips()}
 		<div>
 			<div class="space-y-4">
-				<p class="text-gray-700">
+				<p class="text-gray-700 dark:text-gray-300">
 					這個練習展示了如何使用現代的 Intersection Observer API 來創建滾動動畫效果，相比傳統的
 					scroll 事件監聽，具有更好的性能表現。
 				</p>
-				<div class="rounded-lg border border-blue-200 bg-blue-50 p-4">
-					<h4 class="mb-2 font-semibold text-blue-900">💡 學習要點：</h4>
-					<ul class="space-y-1 text-sm text-blue-800">
+				<div
+					class="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900"
+				>
+					<h4 class="mb-2 font-semibold text-blue-900 dark:text-blue-300">💡 學習要點：</h4>
+					<ul class="space-y-1 text-sm text-blue-800 dark:text-blue-200">
 						<li>• Intersection Observer 比 scroll 事件更高效</li>
 						<li>• CSS transform 比改變 position 屬性性能更好</li>
 						<li>• 適當的 transition timing 讓動畫更自然</li>

--- a/src/routes/practices/css/2/+page.svelte
+++ b/src/routes/practices/css/2/+page.svelte
@@ -89,12 +89,14 @@
 	{#snippet tips()}
 		<div>
 			<div class="space-y-4">
-				<p class="text-gray-700">
+				<p class="text-gray-700 dark:text-gray-300">
 					這個練習展示了 CSS :not() 偽類選擇器的強大功能，通過組合 :hover 狀態創造出獨特的互動效果。
 				</p>
-				<div class="rounded-lg border border-blue-200 bg-blue-50 p-4">
-					<h4 class="mb-2 font-semibold text-blue-900">💡 學習要點：</h4>
-					<ul class="space-y-1 text-sm text-blue-800">
+				<div
+					class="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900"
+				>
+					<h4 class="mb-2 font-semibold text-blue-900 dark:text-blue-300">💡 學習要點：</h4>
+					<ul class="space-y-1 text-sm text-blue-800 dark:text-blue-200">
 						<li>• :not() 選擇器可以排除特定狀態的元素</li>
 						<li>• 組合偽類選擇器創造複雜的互動效果</li>
 						<li>• CSS transform 和 transition 的配合使用</li>

--- a/src/routes/practices/css/3/+page.svelte
+++ b/src/routes/practices/css/3/+page.svelte
@@ -123,13 +123,15 @@ function updateProgress(element, value) {
 	{#snippet tips()}
 		<div>
 			<div class="space-y-4">
-				<p class="text-gray-700">
+				<p class="text-gray-700 dark:text-gray-300">
 					這個練習展示了 CSS conic-gradient()
 					的強大功能，可以創建各種圓形漸層效果，特別適合製作進度條和圖表。
 				</p>
-				<div class="rounded-lg border border-blue-200 bg-blue-50 p-4">
-					<h4 class="mb-2 font-semibold text-blue-900">💡 學習要點：</h4>
-					<ul class="space-y-1 text-sm text-blue-800">
+				<div
+					class="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900"
+				>
+					<h4 class="mb-2 font-semibold text-blue-900 dark:text-blue-300">💡 學習要點：</h4>
+					<ul class="space-y-1 text-sm text-blue-800 dark:text-blue-200">
 						<li>• conic-gradient() 從中心點開始的圓錐漸層</li>
 						<li>• CSS 自定義屬性讓樣式更靈活</li>
 						<li>• ::before 偽元素創造內圓效果</li>

--- a/src/routes/practices/css/6/+page.svelte
+++ b/src/routes/practices/css/6/+page.svelte
@@ -104,12 +104,14 @@
 	{#snippet tips()}
 		<div>
 			<div class="space-y-4">
-				<p class="text-gray-700">
+				<p class="text-gray-700 dark:text-gray-300">
 					這個練習展示了如何使用 CSS 偽類選擇器創建流暢的表單動畫，提升使用者體驗。
 				</p>
-				<div class="rounded-lg border border-blue-200 bg-blue-50 p-4">
-					<h4 class="mb-2 font-semibold text-blue-900">💡 學習要點：</h4>
-					<ul class="space-y-1 text-sm text-blue-800">
+				<div
+					class="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900"
+				>
+					<h4 class="mb-2 font-semibold text-blue-900 dark:text-blue-300">💡 學習要點：</h4>
+					<ul class="space-y-1 text-sm text-blue-800 dark:text-blue-200">
 						<li>• :focus 偽類在元素獲得焦點時觸發</li>
 						<li>• :valid 偽類在輸入內容有效時觸發</li>
 						<li>• pointer-events: none 讓標籤不阻擋點擊</li>

--- a/src/routes/practices/css/7/+page.svelte
+++ b/src/routes/practices/css/7/+page.svelte
@@ -155,12 +155,14 @@ const seconds = formatTime(date.getSeconds());`,
 	{#snippet tips()}
 		<div>
 			<div class="space-y-4">
-				<p class="text-gray-700">
+				<p class="text-gray-700 dark:text-gray-300">
 					這個練習展示了如何結合 JavaScript 的 Date 物件和 CSS 樣式創建一個功能完整的數位時鐘。
 				</p>
-				<div class="rounded-lg border border-blue-200 bg-blue-50 p-4">
-					<h4 class="mb-2 font-semibold text-blue-900">💡 學習要點：</h4>
-					<ul class="space-y-1 text-sm text-blue-800">
+				<div
+					class="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900"
+				>
+					<h4 class="mb-2 font-semibold text-blue-900 dark:text-blue-300">💡 學習要點：</h4>
+					<ul class="space-y-1 text-sm text-blue-800 dark:text-blue-200">
 						<li>• setInterval 用於定時更新顯示</li>
 						<li>• padStart() 方法確保時間格式一致</li>
 						<li>• CSS Grid 和 Flexbox 的組合使用</li>

--- a/src/routes/practices/js/4/+page.svelte
+++ b/src/routes/practices/js/4/+page.svelte
@@ -88,13 +88,15 @@ function toggleMetronome() {
 	{#snippet tips()}
 		<div>
 			<div class="space-y-4">
-				<p class="text-gray-700">
+				<p class="text-gray-700 dark:text-gray-300">
 					這個節拍器展示了如何使用 Web Audio API
 					和定時器創建音樂工具。重點在於精確的時間控制和音頻同步。
 				</p>
-				<div class="rounded-lg border border-blue-200 bg-blue-50 p-4">
-					<h4 class="mb-2 font-semibold text-blue-900">💡 學習要點：</h4>
-					<ul class="space-y-1 text-sm text-blue-800">
+				<div
+					class="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900"
+				>
+					<h4 class="mb-2 font-semibold text-blue-900 dark:text-blue-300">💡 學習要點：</h4>
+					<ul class="space-y-1 text-sm text-blue-800 dark:text-blue-200">
 						<li>• Audio 物件的 preload 屬性可以提升播放性能</li>
 						<li>• 重置 currentTime 確保音頻從頭播放</li>
 						<li>• BPM 轉換公式：60000ms ÷ BPM = 間隔毫秒數</li>

--- a/src/routes/practices/js/5/+page.svelte
+++ b/src/routes/practices/js/5/+page.svelte
@@ -279,13 +279,15 @@ const handleDragOver = (e) => {
 	{#snippet tips()}
 		<div>
 			<div class="space-y-4">
-				<p class="text-gray-700">
+				<p class="text-gray-700 dark:text-gray-300">
 					這個圖片託管工具展示了如何整合多個 Web API
 					來創建完整的檔案上傳功能，包括檔案讀取、編碼轉換和遠端儲存。
 				</p>
-				<div class="rounded-lg border border-blue-200 bg-blue-50 p-4">
-					<h4 class="mb-2 font-semibold text-blue-900">💡 學習要點：</h4>
-					<ul class="space-y-1 text-sm text-blue-800">
+				<div
+					class="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900"
+				>
+					<h4 class="mb-2 font-semibold text-blue-900 dark:text-blue-300">💡 學習要點：</h4>
+					<ul class="space-y-1 text-sm text-blue-800 dark:text-blue-200">
 						<li>• FileReader.readAsDataURL() 將檔案轉為 Base64</li>
 						<li>• GitHub API 可以作為簡單的檔案儲存服務</li>
 						<li>• 適當的錯誤處理和載入狀態很重要</li>

--- a/src/routes/practices/js/8/+page.svelte
+++ b/src/routes/practices/js/8/+page.svelte
@@ -227,12 +227,14 @@ const shareFile = async (file) => {
 	{#snippet tips()}
 		<div>
 			<div class="space-y-4">
-				<p class="text-gray-700">
+				<p class="text-gray-700 dark:text-gray-300">
 					Web Share API 讓網頁可以使用裝置的原生分享功能，提供更好的使用者體驗，特別是在行動裝置上。
 				</p>
-				<div class="rounded-lg border border-blue-200 bg-blue-50 p-4">
-					<h4 class="mb-2 font-semibold text-blue-900">💡 學習要點：</h4>
-					<ul class="space-y-1 text-sm text-blue-800">
+				<div
+					class="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900"
+				>
+					<h4 class="mb-2 font-semibold text-blue-900 dark:text-blue-300">💡 學習要點：</h4>
+					<ul class="space-y-1 text-sm text-blue-800 dark:text-blue-200">
 						<li>• Web Share API 主要在行動裝置上支援</li>
 						<li>• 需要 HTTPS 環境才能使用</li>
 						<li>• 總是要提供備用方案（如複製到剪貼簿）</li>


### PR DESCRIPTION
## Summary
- enable dark mode styling for PracticeLayout
- update practice tips snippets for dark mode

## Testing
- `npx prettier --check src/routes/practices/components/PracticeLayout.svelte src/routes/practices/css/1/+page.svelte src/routes/practices/css/2/+page.svelte src/routes/practices/css/3/+page.svelte src/routes/practices/css/6/+page.svelte src/routes/practices/css/7/+page.svelte src/routes/practices/js/4/+page.svelte src/routes/practices/js/5/+page.svelte src/routes/practices/js/8/+page.svelte`
- `npx eslint src/routes/practices/components/PracticeLayout.svelte src/routes/practices/css/1/+page.svelte src/routes/practices/css/2/+page.svelte src/routes/practices/css/3/+page.svelte src/routes/practices/css/6/+page.svelte src/routes/practices/css/7/+page.svelte src/routes/practices/js/4/+page.svelte src/routes/practices/js/5/+page.svelte src/routes/practices/js/8/+page.svelte`
- `npm test` *(fails: PUBLIC_FIREBASE_API_KEY is not exported by virtual:env/static/public)*

------
https://chatgpt.com/codex/tasks/task_e_689d489c73d48330beac55bfa44fe147