### PR TITLE
Add dark mode to admin pages

### DIFF
--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -185,8 +185,8 @@
 						<FileText size={24} class="text-blue-600" />
 					</div>
 					<div>
-						<div class="text-2xl font-bold text-gray-900">{totalPosts}</div>
-						<div class="text-sm text-gray-600">總文章數</div>
+						<div class="text-2xl font-bold text-gray-900 dark:text-gray-100">{totalPosts}</div>
+						<div class="text-sm text-gray-600 dark:text-gray-500">總文章數</div>
 					</div>
 				</CardContent>
 			</Card>
@@ -197,8 +197,8 @@
 						<Tag size={24} class="text-green-600" />
 					</div>
 					<div>
-						<div class="text-2xl font-bold text-gray-900">{allTags.length}</div>
-						<div class="text-sm text-gray-600">標籤數量</div>
+						<div class="text-2xl font-bold text-gray-900 dark:text-gray-100">{allTags.length}</div>
+						<div class="text-sm text-gray-600 dark:text-gray-500">標籤數量</div>
 					</div>
 				</CardContent>
 			</Card>
@@ -209,8 +209,8 @@
 						<Calendar size={24} class="text-purple-600" />
 					</div>
 					<div>
-						<div class="text-2xl font-bold text-gray-900">{recentPosts.length}</div>
-						<div class="text-sm text-gray-600">最近文章</div>
+						<div class="text-2xl font-bold text-gray-900 dark:text-gray-100">{recentPosts.length}</div>
+						<div class="text-sm text-gray-600 dark:text-gray-500">最近文章</div>
 					</div>
 				</CardContent>
 			</Card>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -660,4 +660,99 @@
 			max-width: none;
 		}
 	}
+
+	:global(.dark) .admin-container {
+		background: #111827;
+	}
+
+	:global(.dark) .sidebar {
+		background: #1f2937;
+		border-right: 1px solid #374151;
+	}
+
+	:global(.dark) .sidebar-header {
+		border-bottom: 1px solid #374151;
+	}
+
+	:global(.dark) .logo {
+		color: #f3f4f6;
+	}
+
+	:global(.dark) .nav-item {
+		color: #9ca3af;
+	}
+
+	:global(.dark) .nav-item:hover {
+		background: #374151;
+		color: #f3f4f6;
+	}
+
+	:global(.dark) .nav-item.active {
+		background: #1e40af;
+		color: #60a5fa;
+		border-right: 3px solid #60a5fa;
+	}
+
+	:global(.dark) .sidebar-footer {
+		border-top: 1px solid #374151;
+	}
+
+	:global(.dark) .logout-btn {
+		color: #9ca3af;
+	}
+
+	:global(.dark) .logout-btn:hover {
+		background: #7f1d1d;
+		color: #fca5a5;
+	}
+
+	:global(.dark) .main-content {
+		color: #d1d5db;
+	}
+
+	:global(.dark) .page-title {
+		color: #f3f4f6;
+	}
+
+	:global(.dark) .page-subtitle {
+		color: #9ca3af;
+	}
+
+	:global(.dark) .filter-group {
+		color: #9ca3af;
+	}
+
+	:global(.dark) .tag-filter {
+		border-color: #4b5563;
+		background: #1f2937;
+		color: #d1d5db;
+	}
+
+	:global(.dark) .posts-table th {
+		background: #1f2937;
+		color: #d1d5db;
+		border-bottom: 1px solid #374151;
+	}
+
+	:global(.dark) .posts-table td {
+		border-bottom: 1px solid #374151;
+	}
+
+	:global(.dark) .table-row:hover {
+		background: #374151;
+	}
+
+	:global(.dark) .post-title-link {
+		color: #f3f4f6;
+	}
+
+	:global(.dark) .post-title-link:hover {
+		color: #60a5fa;
+	}
+
+	:global(.dark) .no-tags,
+	:global(.dark) .brief-text,
+	:global(.dark) .date-cell {
+		color: #9ca3af;
+	}
 </style>

--- a/src/routes/admin/[blogId]/+page.svelte
+++ b/src/routes/admin/[blogId]/+page.svelte
@@ -166,7 +166,7 @@
 
 <div class="min-h-screen bg-gray-50 dark:bg-gray-900">
 	<!-- Header -->
-	<header class="sticky top-0 z-50 border-b bg-white dark:border-gray-800 dark:bg-gray-950">
+	<header class="sticky top-0 z-50 border-b bg-white dark:border-gray-700 dark:bg-gray-900">
 		<div class="flex items-center justify-between p-6">
 			<div class="flex items-center gap-6">
 				<Button variant="ghost" size="sm" onclick={goBack} class="gap-2">

--- a/src/routes/admin/create/+page.svelte
+++ b/src/routes/admin/create/+page.svelte
@@ -109,7 +109,7 @@ console.log('Hello, World!');
 
 <div class="min-h-screen bg-gray-50 dark:bg-gray-900">
 	<!-- Header -->
-	<header class="sticky top-0 z-50 border-b bg-white dark:border-gray-800 dark:bg-gray-950">
+	<header class="sticky top-0 z-50 border-b bg-white dark:border-gray-700 dark:bg-gray-900">
 		<div class="flex items-center justify-between p-6">
 			<div class="flex items-center gap-6">
 				<Button variant="ghost" size="sm" onclick={goBack} class="gap-2">
@@ -256,7 +256,7 @@ console.log('Hello, World!');
 
 						<TabsContent value="preview" class="mt-4">
 							<div
-								class="min-h-[500px] rounded-lg border bg-white p-6 dark:border-gray-800 dark:bg-gray-950"
+								class="min-h-[500px] rounded-lg border bg-white p-6 dark:border-gray-700 dark:bg-gray-800"
 							>
 								<div class="prose max-w-none">
 									{@html marked(content, { mangle: false, headerIds: false })}


### PR DESCRIPTION
## Summary
- support dark theme in admin dashboard with dedicated style overrides
- enable dark mode on admin create and edit pages using Tailwind classes

## Testing
- `npx prettier --plugin-search-dir=. --check src/routes/admin/+page.svelte src/routes/admin/create/+page.svelte src/routes/admin/[blogId]/+page.svelte`
- `npx eslint src/routes/admin/+page.svelte src/routes/admin/create/+page.svelte src/routes/admin/[blogId]/+page.svelte && echo ESLint Passed`
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_689d4cdddf3c83308afd7ab2dab00694