### PR TITLE
feat: add dark mode to admin pages

### DIFF
--- a/src/routes/admin/[blogId]/+page.svelte
+++ b/src/routes/admin/[blogId]/+page.svelte
@@ -164,9 +164,9 @@
 	<meta name="description" content="編輯部落格文章" />
 </svelte:head>
 
-<div class="min-h-screen bg-gray-50">
+<div class="min-h-screen bg-gray-50 dark:bg-gray-900">
 	<!-- Header -->
-	<header class="sticky top-0 z-50 border-b bg-white">
+	<header class="sticky top-0 z-50 border-b bg-white dark:border-gray-800 dark:bg-gray-950">
 		<div class="flex items-center justify-between p-6">
 			<div class="flex items-center gap-6">
 				<Button variant="ghost" size="sm" onclick={goBack} class="gap-2">
@@ -174,8 +174,8 @@
 					返回列表
 				</Button>
 				<div>
-					<h1 class="text-2xl font-bold text-gray-900">編輯文章</h1>
-					<div class="mt-1 flex items-center gap-4 text-sm text-gray-600">
+					<h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">編輯文章</h1>
+					<div class="mt-1 flex items-center gap-4 text-sm text-gray-600 dark:text-gray-400">
 						<span class="flex items-center gap-1">
 							<User size={14} />
 							文章 ID: {id}
@@ -233,17 +233,21 @@
 			<CardContent>
 				<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 					<div class="flex items-center gap-3">
-						<Calendar size={16} class="text-gray-500" />
+						<Calendar size={16} class="text-gray-500 dark:text-gray-400" />
 						<div>
-							<div class="text-xs font-medium text-gray-500">建立時間</div>
-							<div class="text-sm font-medium text-gray-900">{formatDateWithTime(createdAt)}</div>
+							<div class="text-xs font-medium text-gray-500 dark:text-gray-400">建立時間</div>
+							<div class="text-sm font-medium text-gray-900 dark:text-gray-100">
+								{formatDateWithTime(createdAt)}
+							</div>
 						</div>
 					</div>
 					<div class="flex items-center gap-3">
-						<Clock size={16} class="text-gray-500" />
+						<Clock size={16} class="text-gray-500 dark:text-gray-400" />
 						<div>
-							<div class="text-xs font-medium text-gray-500">最後更新</div>
-							<div class="text-sm font-medium text-gray-900">{formatDateWithTime(updatedAt)}</div>
+							<div class="text-xs font-medium text-gray-500 dark:text-gray-400">最後更新</div>
+							<div class="text-sm font-medium text-gray-900 dark:text-gray-100">
+								{formatDateWithTime(updatedAt)}
+							</div>
 						</div>
 					</div>
 				</div>
@@ -320,7 +324,7 @@
 								rows={3}
 								class="resize-none"
 							/>
-							<div class="text-right text-xs text-gray-500">
+							<div class="text-right text-xs text-gray-500 dark:text-gray-400">
 								{brief.length} / 200 字符
 							</div>
 						</div>
@@ -343,7 +347,7 @@
 							<CardTitle>文章內容</CardTitle>
 							<CardDescription>使用 Markdown 語法編輯文章內容</CardDescription>
 						</div>
-						<div class="flex items-center gap-4 text-sm text-gray-500">
+						<div class="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
 							<span>{content.length} 字符</span>
 							<Separator orientation="vertical" class="h-4" />
 							<span>支援 Markdown</span>
@@ -369,7 +373,9 @@
 						</TabsContent>
 
 						<TabsContent value="preview" class="mt-4">
-							<div class="min-h-[500px] rounded-lg border bg-white p-6">
+							<div
+								class="min-h-[500px] rounded-lg border bg-white p-6 dark:border-gray-800 dark:bg-gray-950"
+							>
 								<div class="prose max-w-none">
 									{@html marked(content, { mangle: false, headerIds: false })}
 								</div>

--- a/src/routes/admin/create/+page.svelte
+++ b/src/routes/admin/create/+page.svelte
@@ -107,9 +107,9 @@ console.log('Hello, World!');
 	<meta name="description" content="建立新的部落格文章" />
 </svelte:head>
 
-<div class="min-h-screen bg-gray-50">
+<div class="min-h-screen bg-gray-50 dark:bg-gray-900">
 	<!-- Header -->
-	<header class="sticky top-0 z-50 border-b bg-white">
+	<header class="sticky top-0 z-50 border-b bg-white dark:border-gray-800 dark:bg-gray-950">
 		<div class="flex items-center justify-between p-6">
 			<div class="flex items-center gap-6">
 				<Button variant="ghost" size="sm" onclick={goBack} class="gap-2">
@@ -117,8 +117,8 @@ console.log('Hello, World!');
 					返回列表
 				</Button>
 				<div>
-					<h1 class="text-2xl font-bold text-gray-900">建立新文章</h1>
-					<p class="text-sm text-gray-600">撰寫並發布您的部落格文章</p>
+					<h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">建立新文章</h1>
+					<p class="text-sm text-gray-600 dark:text-gray-400">撰寫並發布您的部落格文章</p>
 				</div>
 			</div>
 		</div>
@@ -189,7 +189,7 @@ console.log('Hello, World!');
 								rows={3}
 								class="resize-none"
 							/>
-							<div class="text-right text-xs text-gray-500">
+							<div class="text-right text-xs text-gray-500 dark:text-gray-400">
 								{brief.length} / 200 字符
 							</div>
 						</div>
@@ -229,7 +229,7 @@ console.log('Hello, World!');
 							<CardTitle>文章內容</CardTitle>
 							<CardDescription>使用 Markdown 語法撰寫文章內容</CardDescription>
 						</div>
-						<div class="flex items-center gap-4 text-sm text-gray-500">
+						<div class="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
 							<span>{content.length} 字符</span>
 							<Separator orientation="vertical" class="h-4" />
 							<span>支援 Markdown</span>
@@ -255,7 +255,9 @@ console.log('Hello, World!');
 						</TabsContent>
 
 						<TabsContent value="preview" class="mt-4">
-							<div class="min-h-[500px] rounded-lg border bg-white p-6">
+							<div
+								class="min-h-[500px] rounded-lg border bg-white p-6 dark:border-gray-800 dark:bg-gray-950"
+							>
 								<div class="prose max-w-none">
 									{@html marked(content, { mangle: false, headerIds: false })}
 								</div>


### PR DESCRIPTION
## Summary
- add dark mode styles to admin create page
- add dark mode styles to admin edit page

## Testing
- `yarn lint` *(fails: Code style issues found in src/routes/register/+page.svelte)*
- `yarn test` *(fails: build failed, missing PUBLIC_FIREBASE_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_689d4ceb59f88330ad70c8b0f77dd805